### PR TITLE
fix: strip URI scheme from OTLP endpoint before passing to gRPC exporter

### DIFF
--- a/internal/telemetry/tracing.go
+++ b/internal/telemetry/tracing.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
 
 	"go.opentelemetry.io/otel"
@@ -52,6 +53,31 @@ type customTracer struct {
 	samplingRatio float64
 }
 
+// parseOTLPEndpoint extracts the host:port from an endpoint string that may
+// contain a URI scheme (e.g. "http://host:4317"). The OTEL_EXPORTER_OTLP_ENDPOINT
+// env var uses full URIs per the OpenTelemetry spec, but the gRPC exporter's
+// WithEndpoint expects a bare host:port.
+//
+// Returns the cleaned endpoint and whether the scheme indicates an insecure
+// (http) connection.
+func parseOTLPEndpoint(endpoint string) (string, bool) {
+	u, err := url.Parse(endpoint)
+	if err != nil || u.Host == "" {
+		// Not a valid URI — treat as a bare host:port.
+		return endpoint, false
+	}
+
+	switch u.Scheme {
+	case "http":
+		return u.Host, true
+	case "https":
+		return u.Host, false
+	default:
+		// Unknown scheme — return as-is.
+		return endpoint, false
+	}
+}
+
 func MustNewTracerProvider(opts ...TracerOption) *sdktrace.TracerProvider {
 	tracer := &customTracer{
 		endpoint:      "",
@@ -79,15 +105,17 @@ func MustNewTracerProvider(opts ...TracerOption) *sdktrace.TracerProvider {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
+	endpoint, schemeInsecure := parseOTLPEndpoint(tracer.endpoint)
+
 	options := []otlptracegrpc.Option{
-		otlptracegrpc.WithEndpoint(tracer.endpoint),
+		otlptracegrpc.WithEndpoint(endpoint),
 		otlptracegrpc.WithDialOption(
 			// nolint:staticcheck // ignoring gRPC deprecations
 			grpc.WithBlock(),
 		),
 	}
 
-	if tracer.insecure {
+	if tracer.insecure || schemeInsecure {
 		options = append(options, otlptracegrpc.WithInsecure())
 	}
 

--- a/internal/telemetry/tracing_test.go
+++ b/internal/telemetry/tracing_test.go
@@ -1,0 +1,81 @@
+package telemetry
+
+import (
+	"testing"
+)
+
+func TestParseOTLPEndpoint(t *testing.T) {
+	tests := []struct {
+		name             string
+		input            string
+		expectedEndpoint string
+		expectedInsecure bool
+	}{
+		{
+			name:             "bare_host_port",
+			input:            "collector.example.com:4317",
+			expectedEndpoint: "collector.example.com:4317",
+			expectedInsecure: false,
+		},
+		{
+			name:             "http_scheme",
+			input:            "http://collector.example.com:4317",
+			expectedEndpoint: "collector.example.com:4317",
+			expectedInsecure: true,
+		},
+		{
+			name:             "https_scheme",
+			input:            "https://collector.example.com:4317",
+			expectedEndpoint: "collector.example.com:4317",
+			expectedInsecure: false,
+		},
+		{
+			name:             "http_k8s_service_dns",
+			input:            "http://k8se-otel.k8se-apps.svc.cluster.local:4317",
+			expectedEndpoint: "k8se-otel.k8se-apps.svc.cluster.local:4317",
+			expectedInsecure: true,
+		},
+		{
+			name:             "localhost",
+			input:            "0.0.0.0:4317",
+			expectedEndpoint: "0.0.0.0:4317",
+			expectedInsecure: false,
+		},
+		{
+			name:             "http_localhost",
+			input:            "http://localhost:4317",
+			expectedEndpoint: "localhost:4317",
+			expectedInsecure: true,
+		},
+		{
+			name:             "https_no_port",
+			input:            "https://collector.example.com",
+			expectedEndpoint: "collector.example.com",
+			expectedInsecure: false,
+		},
+		{
+			name:             "http_no_port",
+			input:            "http://collector.example.com",
+			expectedEndpoint: "collector.example.com",
+			expectedInsecure: true,
+		},
+		{
+			name:             "empty_string",
+			input:            "",
+			expectedEndpoint: "",
+			expectedInsecure: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint, insecure := parseOTLPEndpoint(tt.input)
+			if endpoint != tt.expectedEndpoint {
+				t.Errorf("parseOTLPEndpoint(%q) endpoint = %q, want %q", tt.input, endpoint, tt.expectedEndpoint)
+			}
+			if insecure != tt.expectedInsecure {
+				t.Errorf("parseOTLPEndpoint(%q) insecure = %v, want %v", tt.input, insecure, tt.expectedInsecure)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`OTEL_EXPORTER_OTLP_ENDPOINT` uses full URIs (`http://host:4317`) per the OpenTelemetry spec, but `otlptracegrpc.WithEndpoint()` expects a bare `host:port`. This causes gRPC dial failures with `"too many colons in address"` when the env var includes a scheme.

Adds `parseOTLPEndpoint()` to strip `http://` / `https://` schemes and infer insecure mode from `http://`.

## Related Issue(s)



## How to test

```bash
go test ./internal/telemetry/ -run TestParseOTLPEndpoint -v
```

Set `OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317` and verify traces export without the `"too many colons"` error.